### PR TITLE
Update cluster_logfc.R and wmw_gsea.R for compatibility with R>=4.0.0

### DIFF
--- a/R/cluster_logfc.R
+++ b/R/cluster_logfc.R
@@ -16,7 +16,8 @@ if (is.factor(cluster.ids)==F) {
   cluster.ids <- as.factor(cluster.ids)
 }
 
-if (!class(expr.mat)=="dgCMatrix") {
+if (!inherits(expr.mat, "dgCMatrix")) {
+#if (!class(expr.mat)=="dgCMatrix") {
 	expr.mat <- Matrix(expr.mat,sparse=TRUE)
 }
 

--- a/R/wmw_gsea.R
+++ b/R/wmw_gsea.R
@@ -18,7 +18,8 @@ wmw_gsea <- function(expr.mat,cluster.cells,log.fc.cluster,gene.sets)
 
 {
 
-if (!class(expr.mat)=="matrix") {
+if (!inherits(expr.mat, "matrix")) {
+#if (!class(expr.mat)=="matrix") {
 	expr.mat <- as.matrix(expr.mat)
 }
 


### PR DESCRIPTION
Updated cluster_logfc.R and wmw_gsea.R for compatibility with R >4.0.0. Since R 4.0.0, matrices have two classes, "matrix" and "array", which leads to a "condition has length > 1" error when running, e.g., `if (!class(expr.mat)=="dgCMatrix")`. The "inherits" or "is" functions should be used instead of "==" for checking the class (https://developer.r-project.org/Blog/public/2019/11/09/when-you-think-class.-think-again/index.html).
@svigneau